### PR TITLE
Add role string to users

### DIFF
--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -1,6 +1,6 @@
 import { NextAuthOptions, TokenSet } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
-import { PrismaAdapter } from "@auth/prisma-adapter";
+import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import prisma from "@/prisma/global-prisma-client";
 
 export const authOptions: NextAuthOptions = {
@@ -57,6 +57,7 @@ export const authOptions: NextAuthOptions = {
           id: profile.me.id,
           name: profile.me.name,
           image: profile.me.avatar.thumb_url,
+          role: "user",
           // TODO: get WCA ID
         };
       },
@@ -66,8 +67,26 @@ export const authOptions: NextAuthOptions = {
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      profile(profile) {
+        return {
+          id: profile.sub,
+          name: profile.name,
+          image: profile.picture,
+          email: profile.email,
+          role: "user",
+        };
+      },
     }),
   ],
+  session: {
+    strategy: "database",
+  },
+  callbacks: {
+    async session({ session, user }) {
+      session.user.role = user.role;
+      return session;
+    },
+  },
   // pages: {
   //   // TODO: implement custom sign-in page
   //   signIn: "/login",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^1.0.2",
+        "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.2.0",
         "@radix-ui/react-avatar": "^1.0.3",
         "@radix-ui/react-dropdown-menu": "^2.0.5",
@@ -328,6 +329,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@next-auth/prisma-adapter": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@next-auth/prisma-adapter/-/prisma-adapter-1.0.7.tgz",
+      "integrity": "sha512-Cdko4KfcmKjsyHFrWwZ//lfLUbcLqlyFqjd/nYE2m3aZ7tjMNUjpks47iw7NTCnXf+5UWz5Ypyt1dSs1EP5QJw==",
+      "peerDependencies": {
+        "@prisma/client": ">=2.26.0 || >=3",
+        "next-auth": "^4"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postinstall": "prisma generate"
   },
   "dependencies": {
-    "@auth/prisma-adapter": "^1.0.2",
+    "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^5.2.0",
     "@radix-ui/react-avatar": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.5",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   email         String?   @unique
   emailVerified DateTime?
   image         String?
+  role          String    @default("user")
   accounts      Account[]
   sessions      Session[]
 }

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,20 @@
+import NextAuth, { DefaultSession, DefaultUser } from "next-auth";
+
+// In order to use custom properties for users, like `role`,
+// you need to extend the `Session` and `User` types from NextAuth.
+// See https://authjs.dev/getting-started/typescript
+
+declare module "next-auth" {
+  /**
+   * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
+   */
+  interface Session {
+    user: {
+      role: string;
+    } & DefaultSession["user"];
+  }
+
+  interface User extends DefaultUser {
+    role: string;
+  }
+}


### PR DESCRIPTION
This change adds a `role` property to users, which is a string. This can be used to determine different classes of users who may use the application. This will allow us to restrict access to parts of the application depending on the user's role, such as when adding new algs or sets. 

Currently, all users will be set to the default `"user"` role, which represents the typical end user. We can manually add other users as roles by modifying their entry in the User table directly.