### PR TITLE
Collect email and WCA ID on WCA login

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ More details [here](https://next-auth.js.org/configuration/options#environment-v
 
 1. [Create an OAuth application](https://www.worldcubeassociation.org/oauth/applications/new).
 2. Set the Redirect URI to `http://localhost:3000/api/auth/callback/wca` for development, or `https://{YOUR_DOMAIN}/api/auth/callback/wca` for production.
-3. Leave scopes blank and click Submit.
+3. Set the Scopes to `public email` and click Submit.
 4. Update your `.env` file with the credentials shown on the page. "Application ID" is the `WCA_CLIENT_ID`, and "Secret" is the `WCA_CLIENT_SECRET`.
 
 ### Setting up Google OAuth

--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -15,7 +15,7 @@ export const authOptions: NextAuthOptions = {
       authorization: {
         url: "https://www.worldcubeassociation.org/oauth/authorize",
         params: {
-          scope: "public",
+          scope: "public email",
         },
       },
       token: {
@@ -57,8 +57,9 @@ export const authOptions: NextAuthOptions = {
           id: profile.me.id,
           name: profile.me.name,
           image: profile.me.avatar.thumb_url,
+          email: profile.me.email,
           role: "user",
-          // TODO: get WCA ID
+          wcaId: profile.me.wca_id,
         };
       },
       clientId: process.env.WCA_CLIENT_ID!,
@@ -84,6 +85,7 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     async session({ session, user }) {
       session.user.role = user.role;
+      session.user.wcaId = user.wcaId;
       return session;
     },
   },

--- a/components/user-account-nav.tsx
+++ b/components/user-account-nav.tsx
@@ -13,7 +13,7 @@ import {
 import { UserAvatar } from "@/components/user-avatar";
 
 interface UserAccountNavProps extends React.HTMLAttributes<HTMLDivElement> {
-  user: Pick<User, "name" | "image" | "email">;
+  user: Pick<User, "name" | "image" | "email" | "wcaId">;
 }
 
 export function UserAccountNav({ user }: UserAccountNavProps) {
@@ -29,9 +29,9 @@ export function UserAccountNav({ user }: UserAccountNavProps) {
         <div className="flex items-center justify-start gap-2 p-2">
           <div className="flex flex-col space-y-1 leading-none">
             {user.name && <p className="font-medium">{user.name}</p>}
-            {user.email && (
+            {(user.wcaId || user.email) && (
               <p className="w-[200px] truncate text-sm text-muted-foreground">
-                {user.email}
+                {user.wcaId ?? user.email}
               </p>
             )}
           </div>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   email         String?   @unique
   emailVerified DateTime?
   image         String?
+  wcaId         String?
   role          String    @default("user")
   accounts      Account[]
   sessions      Session[]

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -11,10 +11,12 @@ declare module "next-auth" {
   interface Session {
     user: {
       role: string;
+      wcaId?: string;
     } & DefaultSession["user"];
   }
 
   interface User extends DefaultUser {
     role: string;
+    wcaId?: string;
   }
 }


### PR DESCRIPTION
By default, WCA's OAuth API doesn't give us the emails of WCA accounts. I found out that we can get it by adding "email" to the list of OAuth scopes. Having the email of WCA users will be useful. For example, it prevents the same user from signing in with both WCA and Google (if both use the same email). Here's what NextAuth does:
![Screenshot 2023-10-06 001516](https://github.com/nsilvestri/algdb/assets/50253028/7d82ef06-6376-4f77-a821-297ffe7a9271)

I've also added WCA ID to users. If signed in with WCA, clicking on the user profile icon will show the WCA ID.

# Required actions on local and prod
- Update the scopes from blank to `public email` on WCA OAuth
- Run `npx prisma db push` because the schema has changed

For testing locally, it's probably best to delete the users first. Can be done by running this SQL on your dev database:
```
DELETE FROM User;
DELETE FROM Session;
DELETE FROM Account;
```