### PR TITLE
Fix Prisma 10 instance warning

### DIFF
--- a/prisma/global-prisma-client.ts
+++ b/prisma/global-prisma-client.ts
@@ -1,5 +1,19 @@
+// from https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices
+
 import { PrismaClient } from "@prisma/client";
 
-const prisma = new PrismaClient();
+const prismaClientSingleton = () => {
+  return new PrismaClient();
+};
+
+type PrismaClientSingleton = ReturnType<typeof prismaClientSingleton>;
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClientSingleton | undefined;
+};
+
+const prisma = globalForPrisma.prisma ?? prismaClientSingleton();
 
 export default prisma;
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
The global Prisma object was incorrectly configured, and a new one was being instantiated when one already existed.
This commit fixes this warning using the example given in [Prisma's own documentation](https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices).