### PR TITLE
Fix crash when alg cannot be parsed

### DIFF
--- a/components/add-set-form.tsx
+++ b/components/add-set-form.tsx
@@ -378,9 +378,16 @@ export default function AddSetForm({ puzzles }: AddSetFormProps) {
                       ...(options as SVGVisualizerOptions),
                       puzzle: {
                         ...(options as SVGVisualizerOptions).puzzle,
-                        alg: new Alg(c.algorithms[0]?.alg || "")
-                          .invert()
-                          .toString(),
+                        alg: (() => {
+                          // try/catch will catch any unparseable algs
+                          try {
+                            return new Alg(c.algorithms[0]?.alg || "")
+                              .invert()
+                              .toString();
+                          } catch (e) {
+                            return "";
+                          }
+                        })(),
                       },
                     }}
                   />


### PR DESCRIPTION
cubing.js would throw an error when trying to create an `Alg` with a string that couldn't be parsed to an alg. This would cause the page the crash and the user to lose all progress on the page when entering data, such as when entering a new set. This fixes the crash.

I'm not happy about the level of indentation here but this change is isolated enough to unblock the issue and make the page more usable.