### PR TITLE
Fix sidebar showing duplicate set names

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -63,7 +63,7 @@ export default async function RootLayout({
     {
       title: "Algorithm Sets",
       items: sets.map((set) => ({
-        title: set.name,
+        title: `${set.name} - ${set.puzzle.name}`,
         href: `/puzzles/${set.puzzle.slug}/sets/${set.slug}`,
       })),
     },


### PR DESCRIPTION
Some sets share the same name, because they refer to equivalent steps on different puzzles. This commit adds the puzzle name to the link to the set in the navbar.

Long-term another solution will need to be found, as right now the navbar takes all the sets present in the database and creates an entry for them, so it will probably be too big in the future. But for now, this will work fine to distinguish the sets, and a better solution can be found at some point in the future.