### PR TITLE
Add case-alg relationship as explicit table

### DIFF
--- a/app/(routes)/puzzles/[puzzleSlug]/sets/[setSlug]/page.tsx
+++ b/app/(routes)/puzzles/[puzzleSlug]/sets/[setSlug]/page.tsx
@@ -24,7 +24,11 @@ export default async function Page({
       visualization: true,
       cases: {
         include: {
-          algorithms: true,
+          algorithmsForCase: {
+            include: {
+              algorithm: true,
+            },
+          },
         },
       },
     },
@@ -55,12 +59,12 @@ export default async function Page({
                 </div>
                 <Separator orientation="vertical" />
                 <div className="flex flex-col gap-y-1 flex-grow">
-                  {c.algorithms.map((a, i) => {
-                    const isLast = i === c.algorithms.length - 1;
+                  {c.algorithmsForCase.map((afc, i) => {
+                    const isLast = i === c.algorithmsForCase.length - 1;
                     return (
                       <>
                         <div>
-                          <p>{a.moves}</p>
+                          <p>{afc.algorithm.moves}</p>
                         </div>
                         {!isLast && <Separator />}
                       </>

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "cubing": "^0.43.4",
+        "cuid": "^3.0.0",
         "eslint": "8.47.0",
         "eslint-config-next": "13.4.19",
         "lucide-react": "^0.268.0",
@@ -2081,6 +2082,12 @@
       "engines": {
         "node": ">=19"
       }
+    },
+    "node_modules/cuid": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-3.0.0.tgz",
+      "integrity": "sha512-WZYYkHdIDnaxdeP8Misq3Lah5vFjJwGuItJuV+tvMafosMzw0nF297T7mrm8IOWiPJkV6gc7sa8pzx27+w25Zg==",
+      "deprecated": "Cuid and other k-sortable and non-cryptographic ids (Ulid, ObjectId, KSUID, all UUIDs) are all insecure. Use @paralleldrive/cuid2 instead."
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "cubing": "^0.43.4",
+    "cuid": "^3.0.0",
     "eslint": "8.47.0",
     "eslint-config-next": "13.4.19",
     "lucide-react": "^0.268.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,21 +92,37 @@ model Set {
 }
 
 model Case {
-  id         String      @id @default(cuid())
-  name       String
-  setup      String
-  puzzle     Puzzle      @relation(fields: [puzzleId], references: [id])
-  puzzleId   String
-  sets       Set[]
-  algorithms Algorithm[]
+  id                String              @id @default(cuid())
+  name              String
+  setup             String
+  puzzle            Puzzle              @relation(fields: [puzzleId], references: [id])
+  puzzleId          String
+  sets              Set[]
+  algorithms        Algorithm[]
+  algorithmsForCase AlgorithmsForCase[] // TODO: rename to "algorithms" when that namespace is available
 
   @@index([puzzleId])
 }
 
 model Algorithm {
-  id    String @id @default(cuid())
-  moves String
-  cases Case[]
+  id                String              @id @default(cuid())
+  moves             String
+  algorithmsForCase AlgorithmsForCase[] // TODO: rename to "cases" when Case.algorithms is available
+  Case              Case?               @relation(fields: [caseId], references: [id])
+  caseId            String?
+
+  @@index([caseId])
+}
+
+model AlgorithmsForCase {
+  id          String    @id @default(cuid())
+  algorithm   Algorithm @relation(fields: [algorithmId], references: [id])
+  algorithmId String
+  case        Case      @relation(fields: [caseId], references: [id])
+  caseId      String
+
+  @@index([algorithmId])
+  @@index([caseId])
 }
 
 model Visualization {

--- a/prisma/seed-data/algorithm.ts
+++ b/prisma/seed-data/algorithm.ts
@@ -1,0 +1,41 @@
+import { Prisma } from "@prisma/client";
+import cuid from "cuid";
+
+export const tPerm: Prisma.AlgorithmCreateInput = {
+  id: cuid(),
+  moves: "R U R' U' R' F R2 U' R' U' R U R' F'",
+};
+
+export const jPerm: Prisma.AlgorithmCreateInput = {
+  id: cuid(),
+  moves: "R U R' F' R U R' U' R' F R2 U' R'",
+};
+
+export const yPerm: Prisma.AlgorithmCreateInput = {
+  id: cuid(),
+  moves: "F R U' R' U' R U R' F' R U R' U' R' F R F'",
+};
+
+export const bars2x2_1: Prisma.AlgorithmCreateInput = {
+  id: cuid(),
+  moves: "R2 F2 R2",
+};
+
+export const bars2x2_2: Prisma.AlgorithmCreateInput = {
+  id: cuid(),
+  moves: "R2 B2 R2",
+};
+
+export const bars2x2_3: Prisma.AlgorithmCreateInput = {
+  id: cuid(),
+  moves: "x R2 U2 R2",
+};
+
+export const algorithms = [
+  tPerm,
+  jPerm,
+  yPerm,
+  bars2x2_1,
+  bars2x2_2,
+  bars2x2_3,
+];

--- a/prisma/seed-data/algorithms-for-case.ts
+++ b/prisma/seed-data/algorithms-for-case.ts
@@ -1,0 +1,115 @@
+import { Prisma } from "@prisma/client";
+import {
+  pbl2x2JPerm,
+  pbl2x2YPerm,
+  pbl2x2VerticalBars,
+  pbl2x2AdjAdj,
+  pbl2x2AdjOpp,
+} from "./case";
+import {
+  tPerm,
+  jPerm,
+  yPerm,
+  bars2x2_1,
+  bars2x2_2,
+  bars2x2_3,
+} from "./algorithm";
+
+export const caseAlgorithmLinks: Prisma.AlgorithmsForCaseCreateInput[] = [
+  {
+    case: {
+      connect: {
+        id: pbl2x2JPerm.id,
+      },
+    },
+    algorithm: {
+      connect: {
+        id: tPerm.id,
+      },
+    },
+  },
+  {
+    case: {
+      connect: {
+        id: pbl2x2JPerm.id,
+      },
+    },
+    algorithm: {
+      connect: {
+        id: jPerm.id,
+      },
+    },
+  },
+  {
+    case: {
+      connect: {
+        id: pbl2x2YPerm.id,
+      },
+    },
+    algorithm: {
+      connect: {
+        id: yPerm.id,
+      },
+    },
+  },
+  {
+    case: {
+      connect: {
+        id: pbl2x2VerticalBars.id,
+      },
+    },
+    algorithm: {
+      connect: {
+        id: bars2x2_1.id,
+      },
+    },
+  },
+  {
+    case: {
+      connect: {
+        id: pbl2x2VerticalBars.id,
+      },
+    },
+    algorithm: {
+      connect: {
+        id: bars2x2_2.id,
+      },
+    },
+  },
+  {
+    case: {
+      connect: {
+        id: pbl2x2VerticalBars.id,
+      },
+    },
+    algorithm: {
+      connect: {
+        id: bars2x2_3.id,
+      },
+    },
+  },
+  {
+    case: {
+      connect: {
+        id: pbl2x2AdjAdj.id,
+      },
+    },
+    algorithm: {
+      create: {
+        moves: "R2 U' B2 U2 R2 U' R2",
+      },
+    },
+  },
+  {
+    case: {
+      connect: {
+        id: pbl2x2AdjOpp.id,
+      },
+    },
+    algorithm: {
+      create: {
+        moves: "R U' R F2 R' U R'",
+      },
+    },
+  },
+];

--- a/prisma/seed-data/case.ts
+++ b/prisma/seed-data/case.ts
@@ -1,106 +1,66 @@
 import { Prisma } from "@prisma/client";
 import { twoByTwo } from "./puzzle";
+import cuid from "cuid";
+
+export const pbl2x2JPerm: Prisma.CaseCreateInput = {
+  id: cuid(),
+  name: "J Perm / T Perm",
+  puzzle: {
+    connect: {
+      id: twoByTwo.id,
+    },
+  },
+  setup: "R U R' U' R' F R2 U' R' U' R U R' F' U'",
+};
+
+export const pbl2x2YPerm: Prisma.CaseCreateInput = {
+  id: cuid(),
+  name: "Y Perm",
+  puzzle: {
+    connect: {
+      id: twoByTwo.id,
+    },
+  },
+  setup: "F R U' R' U' R U R' F' R U R' U' R' F R F'",
+};
+
+export const pbl2x2VerticalBars: Prisma.CaseCreateInput = {
+  id: cuid(),
+  name: "Vertical Bars",
+  puzzle: {
+    connect: {
+      id: twoByTwo.id,
+    },
+  },
+  setup: "R2 F2 R2",
+};
+
+export const pbl2x2AdjAdj: Prisma.CaseCreateInput = {
+  id: cuid(),
+  name: "Adj-Adj",
+  puzzle: {
+    connect: {
+      id: twoByTwo.id,
+    },
+  },
+  setup: "R2 U' B2 U2 R2 U' R2",
+};
+
+export const pbl2x2AdjOpp: Prisma.CaseCreateInput = {
+  id: cuid(),
+  name: "Adj-Opp",
+  puzzle: {
+    connect: {
+      id: twoByTwo.id,
+    },
+  },
+  setup: "R U' R F2 R' U R'",
+};
 
 export const pbl2x2Cases: Prisma.CaseCreateInput[] = [
-  {
-    name: "J Perm / T Perm",
-    puzzle: {
-      connect: {
-        id: twoByTwo.id,
-      },
-    },
-    setup: "R U R' U' R' F R2 U' R' U' R U R' F' U'",
-    algorithms: {
-      create: [
-        {
-          moves: "y R U R' U' R' F R2 U' R' U' R U R' F'",
-        },
-        {
-          moves: "y R U R' F' R U R' U' R' F R2 U' R'",
-        },
-      ],
-    },
-  },
-  {
-    name: "Y Perm",
-    puzzle: {
-      connect: {
-        id: twoByTwo.id,
-      },
-    },
-    setup: "F R U' R' U' R U R' F' R U R' U' R' F R F'",
-    algorithms: {
-      create: [
-        {
-          moves: "F R U' R' U' R U R' F' R U R' U' R' F R F'",
-        },
-      ],
-    },
-  },
-  {
-    name: "Vertical Bars",
-    puzzle: {
-      connect: {
-        id: twoByTwo.id,
-      },
-    },
-    setup: "R2 F2 R2",
-    algorithms: {
-      create: [
-        {
-          moves: "R2 F2 R2",
-        },
-        {
-          moves: "R2 B2 R2",
-        },
-        {
-          moves: "x R2 U2 R2",
-        },
-      ],
-    },
-  },
-  {
-    name: "Adj-Adj",
-    puzzle: {
-      connect: {
-        id: twoByTwo.id,
-      },
-    },
-    setup: "R2 U' B2 U2 R2 U' R2",
-    algorithms: {
-      create: [
-        {
-          moves: "R2 U' B2 U2 R2 U' R2",
-        },
-        {
-          moves: "y2 R2 U' R2 U2 F2 U' R2",
-        },
-        {
-          moves: "y2 R2 U' R2 U2 y R2 U' R2",
-        },
-      ],
-    },
-  },
-  {
-    name: "Adj-Opp",
-    puzzle: {
-      connect: {
-        id: twoByTwo.id,
-      },
-    },
-    setup: "R U' R F2 R' U R'",
-    algorithms: {
-      create: [
-        {
-          moves: "R U' R F2 R' U R'",
-        },
-        {
-          moves: "y2 R' U R' F2 R F' R",
-        },
-        {
-          moves: "z2 L D' L F2 L' D L'",
-        },
-      ],
-    },
-  },
+  pbl2x2JPerm,
+  pbl2x2YPerm,
+  pbl2x2VerticalBars,
+  pbl2x2AdjAdj,
+  pbl2x2AdjOpp,
 ];

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,6 +2,8 @@ import { PrismaClient } from "@prisma/client";
 import { puzzles } from "./seed-data/puzzle";
 import { sets } from "./seed-data/set";
 import { methods } from "./seed-data/method";
+import { algorithms } from "./seed-data/algorithm";
+import { caseAlgorithmLinks } from "./seed-data/algorithms-for-case";
 const prisma = new PrismaClient();
 
 async function main() {
@@ -19,6 +21,16 @@ async function main() {
     await prisma.method.create({ data: method });
   });
   await Promise.all(methodPromises);
+
+  const algorithmPromises = algorithms.map(async (algorithm) => {
+    await prisma.algorithm.create({ data: algorithm });
+  });
+  await Promise.all(algorithmPromises);
+
+  const caseAlgorithmLinkPromises = caseAlgorithmLinks.map(async (link) => {
+    await prisma.algorithmsForCase.create({ data: link });
+  });
+  await Promise.all(caseAlgorithmLinkPromises);
 }
 
 main()


### PR DESCRIPTION
We need to store data regarding algorithms and their specific relationships to cases explicitly. This PR creates the explicit table `AlgorithmsForCase` which we can leverage for future features.

Significant changes to seed data was made to support this as well. Seed data will continue to be an ongoing pain.