### PR TITLE
add directUrl and url for Supabase db

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,8 +6,9 @@ generator client {
 }
 
 datasource db {
-  provider     = "mysql"
+  provider     = "postgresql"
   url          = env("DATABASE_URL")
+  directUrl    = env("DIRECT_URL")
   relationMode = "prisma"
 }
 


### PR DESCRIPTION
Planetscale free tier is deprecated. Migrating to Supabase for free DB hosting. Small compatibility changes required.

This only changes the DB host params. We are not using any Supabase features beyond the postgres DB.