### PR TITLE
Add foreign keys and remove unused indices and columns

### DIFF
--- a/prisma/migrations/20240317234533_add_foreign_keys/migration.sql
+++ b/prisma/migrations/20240317234533_add_foreign_keys/migration.sql
@@ -1,0 +1,83 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `caseId` on the `Algorithm` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "Account_userId_idx";
+
+-- DropIndex
+DROP INDEX "Algorithm_caseId_idx";
+
+-- DropIndex
+DROP INDEX "AlgorithmsForCase_algorithmId_idx";
+
+-- DropIndex
+DROP INDEX "AlgorithmsForCase_caseId_idx";
+
+-- DropIndex
+DROP INDEX "Case_puzzleId_idx";
+
+-- DropIndex
+DROP INDEX "Method_puzzleId_idx";
+
+-- DropIndex
+DROP INDEX "Method_visualizationId_idx";
+
+-- DropIndex
+DROP INDEX "Puzzle_visualizationId_idx";
+
+-- DropIndex
+DROP INDEX "Session_userId_idx";
+
+-- DropIndex
+DROP INDEX "Set_puzzleId_idx";
+
+-- DropIndex
+DROP INDEX "Set_visualizationId_idx";
+
+-- AlterTable
+ALTER TABLE "Algorithm" DROP COLUMN "caseId";
+
+-- AddForeignKey
+ALTER TABLE "Account" ADD CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Puzzle" ADD CONSTRAINT "Puzzle_visualizationId_fkey" FOREIGN KEY ("visualizationId") REFERENCES "Visualization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Set" ADD CONSTRAINT "Set_puzzleId_fkey" FOREIGN KEY ("puzzleId") REFERENCES "Puzzle"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Set" ADD CONSTRAINT "Set_visualizationId_fkey" FOREIGN KEY ("visualizationId") REFERENCES "Visualization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Case" ADD CONSTRAINT "Case_puzzleId_fkey" FOREIGN KEY ("puzzleId") REFERENCES "Puzzle"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AlgorithmsForCase" ADD CONSTRAINT "AlgorithmsForCase_algorithmId_fkey" FOREIGN KEY ("algorithmId") REFERENCES "Algorithm"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AlgorithmsForCase" ADD CONSTRAINT "AlgorithmsForCase_caseId_fkey" FOREIGN KEY ("caseId") REFERENCES "Case"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Method" ADD CONSTRAINT "Method_puzzleId_fkey" FOREIGN KEY ("puzzleId") REFERENCES "Puzzle"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Method" ADD CONSTRAINT "Method_visualizationId_fkey" FOREIGN KEY ("visualizationId") REFERENCES "Visualization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_CaseToSet" ADD CONSTRAINT "_CaseToSet_A_fkey" FOREIGN KEY ("A") REFERENCES "Case"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_CaseToSet" ADD CONSTRAINT "_CaseToSet_B_fkey" FOREIGN KEY ("B") REFERENCES "Set"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_MethodToSet" ADD CONSTRAINT "_MethodToSet_A_fkey" FOREIGN KEY ("A") REFERENCES "Method"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_MethodToSet" ADD CONSTRAINT "_MethodToSet_B_fkey" FOREIGN KEY ("B") REFERENCES "Set"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,10 +6,9 @@ generator client {
 }
 
 datasource db {
-  provider     = "postgresql"
-  url          = env("DATABASE_URL")
-  directUrl    = env("DIRECT_URL")
-  relationMode = "prisma"
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model Account {
@@ -29,7 +28,6 @@ model Account {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
-  @@index([userId])
 }
 
 model Session {
@@ -38,8 +36,6 @@ model Session {
   userId       String
   expires      DateTime
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@index([userId])
 }
 
 model User {
@@ -72,8 +68,6 @@ model Puzzle {
   sets            Set[]
   cases           Case[]
   methods         Method[]
-
-  @@index([visualizationId])
 }
 
 model Set {
@@ -87,9 +81,6 @@ model Set {
   cases           Case[]
   methods         Method[]
   methodId        String?
-
-  @@index([puzzleId])
-  @@index([visualizationId])
 }
 
 model Case {
@@ -99,20 +90,13 @@ model Case {
   puzzle            Puzzle              @relation(fields: [puzzleId], references: [id])
   puzzleId          String
   sets              Set[]
-  algorithms        Algorithm[]
   algorithmsForCase AlgorithmsForCase[] // TODO: rename to "algorithms" when that namespace is available
-
-  @@index([puzzleId])
 }
 
 model Algorithm {
   id                String              @id @default(cuid())
   moves             String
   algorithmsForCase AlgorithmsForCase[] // TODO: rename to "cases" when Case.algorithms is available
-  Case              Case?               @relation(fields: [caseId], references: [id])
-  caseId            String?
-
-  @@index([caseId])
 }
 
 model AlgorithmsForCase {
@@ -121,9 +105,6 @@ model AlgorithmsForCase {
   algorithmId String
   case        Case      @relation(fields: [caseId], references: [id])
   caseId      String
-
-  @@index([algorithmId])
-  @@index([caseId])
 }
 
 model Visualization {
@@ -144,7 +125,4 @@ model Method {
   puzzleId        String
   visualization   Visualization @relation(fields: [visualizationId], references: [id])
   visualizationId String
-
-  @@index([puzzleId])
-  @@index([visualizationId])
 }


### PR DESCRIPTION
This PR finalizes the database migration from MySQL to PostgreSQL, and removes the indices that are no longer required by Prisma and columns no longer needed now that an explicit relation table between `Case` and `Algorithm` exists.

Known issues at commit: Set creation dialog doesn't work but I think it needs more time spent there anyway and this is a bigger productivity boost atm.