### PR TITLE
Remove methodId from set schema

### DIFF
--- a/prisma/migrations/20240412025809_remove_method_id_from_set/migration.sql
+++ b/prisma/migrations/20240412025809_remove_method_id_from_set/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `methodId` on the `Set` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Set" DROP COLUMN "methodId";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,7 +80,6 @@ model Set {
   visualizationId String
   cases           Case[]
   methods         Method[]
-  methodId        String?
 }
 
 model Case {


### PR DESCRIPTION
This value in the schema was mistakenly not removed with other changes to the schema that happened.